### PR TITLE
fix bug of push_pop.py

### DIFF
--- a/BlockchainSpider/middlewares/txs/push_pop.py
+++ b/BlockchainSpider/middlewares/txs/push_pop.py
@@ -40,6 +40,8 @@ def adapt_push_item(item: SyncItem) -> Tuple[str, List]:
             edge['symbol'] = ''
             edges.append(edge)
         return node, edges
+    
+    return node, edges
 
 
 class PushAdapterMiddleware(LogMiddleware):


### PR DESCRIPTION
# Description

I came across a bug where the crawler threw an exception and exited early. I ran the crawler with the provided example command, only changing the strategy used from BFS (default) to TTRRedirect:
```
scrapy crawl txs.blockscan -a source=0xeb31973e0febf3e3d7058234a5ebbae1ab4b8c23 -a apikeys=7MM6JYY49WZBXSYFDPYQ3V7V3EMZWE4KJK -a strategy=BlockchainSpider.strategies.txs.TTRRedirect
```
However it quickly crashed with the following logs:
```
2025-07-04 17:26:09 [txs.blockscan] INFO: Your ApiKeys are verified, the spider is starting...
2025-07-04 17:26:10 [BlockchainSpider.middlewares.sync] INFO: Synchronized: 0xeb31973e0febf3e3d7058234a5ebbae1ab4b8c23
2025-07-04 17:26:11 [txs.blockscan] INFO: Pushing: 0xeb31973e0febf3e3d7058234a5ebbae1ab4b8c23, with 246 transfers
2025-07-04 17:26:11 [txs.blockscan] INFO: Popping: 0x34a17418cec67b82d08cf77a987941f99dc87c6b, with args {'residual': 0.5943698015746822, 'allow_all_tokens': True}
2025-07-04 17:26:11 [BlockchainSpider.middlewares.sync] INFO: Synchronized: 0x34a17418cec67b82d08cf77a987941f99dc87c6b
2025-07-04 17:26:11 [txs.blockscan] INFO: Pushing: 0x34a17418cec67b82d08cf77a987941f99dc87c6b, with 178 transfers
2025-07-04 17:26:11 [txs.blockscan] INFO: Popping: 0xa160cdab225685da1d56aa342ad8841c3b53f291, with args {'residual': 0.34530857364674133, 'allow_all_tokens': True}
2025-07-04 17:26:19 [BlockchainSpider.middlewares.sync] INFO: Synchronized: 0xa160cdab225685da1d56aa342ad8841c3b53f291
2025-07-04 17:26:19 [txs.blockscan] INFO: Pushing: 0xa160cdab225685da1d56aa342ad8841c3b53f291, with 8571 transfers
2025-07-04 17:26:19 [txs.blockscan] INFO: Popping: 0xa160cdab225685da1d56aa342ad8841c3b53f291, with args {'residual': 0.20545860131981136, 'allow_all_tokens': True}
2025-07-04 17:26:19 [BlockchainSpider.middlewares.sync] INFO: Synchronized: 0xa160cdab225685da1d56aa342ad8841c3b53f291
2025-07-04 17:26:19 [scrapy.core.scraper] ERROR: Spider error processing <GET https://api.etherscan.io/api?module=account&action=txlist&address=0xa160cdab225685da1d56aa342ad8841c3b53f291&sort=asc&offset=10000&startblock=0&endblock=99999999&apikey=7MM6JYY49WZBXSYFDPYQ3V7V3EMZWE4KJK> (referer: None)
Traceback (most recent call last):
  File "C:\Users\hotcat190\AppData\Local\Programs\Python\Python311\Lib\site-packages\scrapy\utils\defer.py", line 295, in aiter_errback
    yield await it.__anext__()
          ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hotcat190\AppData\Local\Programs\Python\Python311\Lib\site-packages\scrapy\utils\python.py", line 374, in __anext__
    return await self.data.__anext__()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hotcat190\AppData\Local\Programs\Python\Python311\Lib\site-packages\scrapy\utils\python.py", line 355, in _async_chain
    async for o in as_async_generator(it):
  File "C:\Users\hotcat190\AppData\Local\Programs\Python\Python311\Lib\site-packages\scrapy\utils\asyncgen.py", line 14, in as_async_generator
    async for r in it:
  File "C:\Users\hotcat190\AppData\Local\Programs\Python\Python311\Lib\site-packages\scrapy\utils\python.py", line 374, in __anext__
    return await self.data.__anext__()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hotcat190\AppData\Local\Programs\Python\Python311\Lib\site-packages\scrapy\utils\python.py", line 355, in _async_chain
    async for o in as_async_generator(it):
  File "C:\Users\hotcat190\AppData\Local\Programs\Python\Python311\Lib\site-packages\scrapy\utils\asyncgen.py", line 14, in as_async_generator
    async for r in it:
  File "C:\Users\hotcat190\AppData\Local\Programs\Python\Python311\Lib\site-packages\scrapy\core\spidermw.py", line 118, in process_async
    async for r in iterable:
  File "C:\Users\hotcat190\AppData\Local\Programs\Python\Python311\Lib\site-packages\scrapy\spidermiddlewares\offsite.py", line 31, in process_spider_output_async
    async for r in result or ():
  File "C:\Users\hotcat190\AppData\Local\Programs\Python\Python311\Lib\site-packages\scrapy\core\spidermw.py", line 118, in process_async
    async for r in iterable:
  File "D:\dev\aptos\BlockchainSpider\BlockchainSpider\middlewares\txs\push_pop.py", line 55, in process_spider_output
    node, edges = adapt_push_item(item)
    ^^^^^^^^^^^
TypeError: cannot unpack non-iterable NoneType object
2025-07-04 17:26:19 [scrapy.core.engine] INFO: Closing spider (finished)
```

After looking through the code, I determined that the function `adapt_push_item` have a code path that does not return a Tuple if `item['data']` is empty, which causes the `process_spider_output` function to receive a NoneType object and as such cannot unpack the object.

By adding a return statement `return node, edges` at the end of the function `adapt_push_item`, it ensures that the function always return a valid Tuple.

After added the fix myself and running the crawler again, it seems that the crawler is functioning as expected again, although I haven't extensively tested it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually.

**System specifications**:
* OS version: Windows 11 Pro 24H2 OS build 26100.4351
* Hardware: Intel i7-12700K

# Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

